### PR TITLE
Remove `next/font` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "emailing-web",
       "version": "0.1.0",
       "dependencies": {
-        "@next/font": "13.2.4",
         "@radix-ui/react-popover": "^1.0.5",
         "@radix-ui/react-tabs": "^1.0.3",
         "@types/node": "18.15.5",
@@ -466,11 +465,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.2.4.tgz",
-      "integrity": "sha512-lMAnuOYjv5g22WhD00u0DQ9u2rTMJH0S64PKE4Sy8Y2q+FJTYs6ZHT2z3VRoI8+AOWSLK4FirpnygcjOienQ9A=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "13.2.4",
@@ -7963,11 +7957,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.2.4.tgz",
-      "integrity": "sha512-lMAnuOYjv5g22WhD00u0DQ9u2rTMJH0S64PKE4Sy8Y2q+FJTYs6ZHT2z3VRoI8+AOWSLK4FirpnygcjOienQ9A=="
     },
     "@next/swc-android-arm-eabi": {
       "version": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "13.2.4",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-tabs": "^1.0.3",
     "@types/node": "18.15.5",


### PR DESCRIPTION
`next/font` is now part of the `next` package. We can safely remove it.