### PR TITLE
Remove dark mode button and dark mode handling in `FramePreview`

### DIFF
--- a/src/components/ComponentExample/ComponentExample.tsx
+++ b/src/components/ComponentExample/ComponentExample.tsx
@@ -27,7 +27,6 @@ export const ComponentExample = ({
   html,
 }: ComponentExampleProps) => {
   const [codeViewType, setCodeViewType] = useState<Code>("mjml");
-  const [darkMode, setDarkMode] = useState(false);
   const [activeTab, setActiveTab] = useState<"preview" | "code">("preview");
 
   const selectedCode = codeViewType === "mjml" ? mjml : html;
@@ -66,11 +65,6 @@ export const ComponentExample = ({
           <div className="hidden sm:block">
             <CopyButton textToCopy={selectedCode} />
           </div>
-          <div className="hidden sm:block">
-            <IconButton onClick={() => setDarkMode(!darkMode)}>
-              {darkMode ? <SunIcon /> : <MoonIcon />}
-            </IconButton>
-          </div>
         </div>
       </div>
       <div className="mt-4 md:mt-6">
@@ -89,7 +83,6 @@ export const ComponentExample = ({
           <FramePreview
             title={title}
             html={html}
-            darkMode={darkMode}
             className="h-[400px] w-full rounded-3xl border border-dark-100"
           />
         </Tabs.Content>

--- a/src/components/FramePreview/FramePreview.tsx
+++ b/src/components/FramePreview/FramePreview.tsx
@@ -1,11 +1,10 @@
 "use client";
-import { ComponentPropsWithoutRef, useCallback } from "react";
+import { ComponentPropsWithoutRef } from "react";
 import { Resizable } from "re-resizable";
 import { clsx } from "@utils";
 
 export type FramePreviewProps = ComponentPropsWithoutRef<"iframe"> & {
   html: string;
-  darkMode: boolean;
   resizingEnabled?: boolean;
 };
 
@@ -18,22 +17,9 @@ export const FramePreview = ({
   title,
   html,
   className,
-  darkMode,
   resizingEnabled = true,
   ...otherProps
 }: FramePreviewProps) => {
-  const callbackRef = useCallback(
-    (node: HTMLIFrameElement) => {
-      if (node?.contentWindow) {
-        const html = node.contentWindow.document.querySelector("html");
-        if (html) {
-          html.style.colorScheme = `${darkMode ? "dark" : "light"}`;
-        }
-      }
-    },
-    [darkMode]
-  );
-
   return (
     <Resizable
       bounds="parent"
@@ -59,13 +45,9 @@ export const FramePreview = ({
       }}
     >
       <iframe
-        ref={callbackRef}
         id={title}
         title={title}
         srcDoc={html}
-        onLoad={(e) => {
-          callbackRef(e.target as HTMLIFrameElement);
-        }}
         className={clsx("text-clip transition-[max-width]", className)}
         {...otherProps}
       />


### PR DESCRIPTION
Removing the theme button together with theme handling in `FramePreview` component.
We're most likely going to reintroduce the theme button in the future once it's fully working. The developer can then check the source control to get inspiration from the removed functionality.