### PR TITLE
Remove 'Build an email' link, update 'Explore components' link

### DIFF
--- a/src/components/Greeting/Greeting.tsx
+++ b/src/components/Greeting/Greeting.tsx
@@ -40,10 +40,7 @@ export const Greeting = () => (
         tempor.
       </p>
       <div className="mt-6 space-y-3 md:mt-12 md:inline-flex md:gap-x-3 md:space-y-0">
-        <CTA href="/" color="white" className="w-full md:w-auto">
-          Build an email
-        </CTA>
-        <CTA href="/" color="black" className="w-full md:w-auto">
+        <CTA href="/components" color="white" className="w-full md:w-auto">
           Explore components
         </CTA>
       </div>


### PR DESCRIPTION
We forgot to update the two most visible links on the homepage. In this fix we remove the `Build an email` link and update the `Explore components` link. Thanks @jvorcak!