### PR TITLE
Adding React as a teaser option

### DIFF
--- a/src/components/ComponentExample/ComponentExample.tsx
+++ b/src/components/ComponentExample/ComponentExample.tsx
@@ -60,6 +60,10 @@ export const ComponentExample = ({
           >
             <option value="html">HTML</option>
             <option value="mjml">MJML</option>
+            {/* Adding React option as a teaser, implementation is pending */}
+            <option disabled value="react">
+              React
+            </option>
           </select>
           <div className="hidden sm:block">
             <CopyButton textToCopy={selectedCode} />


### PR DESCRIPTION
This PR adds React as a teaser option in the component previews language dropdown. This PR is not meant to be an implementation for supporting React. That will come up in the future. As the title implies, just a "teaser".

![image](https://user-images.githubusercontent.com/77650775/236617915-90f006f3-4ec4-4ade-beee-621d2a1b5c0f.png)

* Closes #75 
