### PR TITLE
Disabling Syntax Highlighting for Development

### DIFF
--- a/src/app/(with-navbar)/components/[type]/page.tsx
+++ b/src/app/(with-navbar)/components/[type]/page.tsx
@@ -102,7 +102,7 @@ const getComponent = async (
 
   const examples = await Promise.all(
     files.map(async (file) => {
-      const id = file.replace(/(\.preview)?\.tsx$/, "");
+      const id = file.replace(/.tsx/, "");
 
       const data = format(readFileSync(join(typePath, file), "utf8"), {
         parser: "typescript",

--- a/src/lib/shiki.ts
+++ b/src/lib/shiki.ts
@@ -48,10 +48,5 @@ export async function highlight(
          class=${className}>${children}</span>`;
       },
     },
-    lineOptions: [
-      {
-        line: 2,
-      },
-    ],
   });
 }

--- a/src/lib/shiki.ts
+++ b/src/lib/shiki.ts
@@ -1,39 +1,57 @@
 import {
-	getHighlighter as getHighlighterFromShiki,
-	renderToHtml,
-	type Highlighter,
-	type Lang,
-	type Theme,
+  getHighlighter as getHighlighterFromShiki,
+  renderToHtml,
+  type Highlighter,
+  type Lang,
+  type Theme,
 } from "shiki";
 
 /** ✅ Config */
 const theme: Theme = "github-dark";
+const langs: Lang[] = ["html", "tsx"];
 const bg: React.CSSProperties["backgroundColor"] = "#011627";
 
 export async function getHighlighter() {
-	/* ✅ Create a highlighter instance with a theme */
-	return await getHighlighterFromShiki({ theme });
+  /** Preload NO languages in development */
+  const isDevelopment = process.env.NODE_ENV === "development";
+
+  /* ✅ Create a highlighter instance with a theme */
+  return await getHighlighterFromShiki({
+    theme,
+    langs: isDevelopment ? [] : langs,
+  });
 }
 
-export async function highlight(highlighter: Highlighter, code: string, lang: Lang = 'tsx') {
-	/* ✅ Highlight your code using the right syntax */
-	const tokens = highlighter.codeToThemedTokens(code, lang);
-	/* ⚠️ Optional: Custom rendering of code blocks */
-	return renderToHtml(tokens, {
-		bg,
-		elements: {
-			pre({ className, style, children }) {
-				return `<pre class="${className}" style="${style}">${children}</pre>`
-			},
-			line({ children, className, index }) {
-				return `<span data-line=${index + 1}
+export async function highlight(
+  highlighter: Highlighter,
+  code: string,
+  lang: Lang = "tsx"
+) {
+  /** Request NO languages in development */
+  const isDevelopment = process.env.NODE_ENV === "development";
+
+  /* ✅ Highlight your code using the right syntax */
+  const tokens = highlighter.codeToThemedTokens(
+    code,
+    isDevelopment ? "" : lang,
+    theme
+  );
+  /* ⚠️ Optional: Custom rendering of code blocks */
+  return renderToHtml(tokens, {
+    bg,
+    elements: {
+      pre({ className, style, children }) {
+        return `<pre class="${className}" style="${style}">${children}</pre>`;
+      },
+      line({ children, className, index }) {
+        return `<span data-line=${index + 1}
          class=${className}>${children}</span>`;
-			},
-		},
-		lineOptions: [
-			{
-				line: 2,
-			},
-		],
-	});
+      },
+    },
+    lineOptions: [
+      {
+        line: 2,
+      },
+    ],
+  });
 }


### PR DESCRIPTION
`shiki` works with minimal effort/configuration and is great with our current setup for statically rendered pages. However, I'm not very happy with how `shiki` is performing during development. I'll investigate to see what options do we have to improve development performance. 

In the meantime this PR introduces the following:

- **Improvement**: Preloading only the languages that we need. For the time being that is `['html', 'tsx']`.
- **Drawback**: During developing disabling all language highlighting, while still keeping all of the formatting in place (see image below).

This will help in the `/components` route when Next prefetches all of the individual sub-routes and also will help when navigating back and forth from these.

![image](https://github.com/webscopeio/mailingui-web/assets/77650775/f72e163b-a087-4574-9b2e-dd37a8ae3adb)
