### PR TITLE
Preview send form

### DIFF
--- a/src/app/preview/components/PreviewNavigation.tsx
+++ b/src/app/preview/components/PreviewNavigation.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { PreviewSend } from "./PreviewSend";
 import { CTA } from "@components/CTA";
 import { BackIcon } from "@components/Icons";
-import { cn } from "@utils/cn";
 
 export const PreviewNavigation = ({
   id,
@@ -13,26 +13,6 @@ export const PreviewNavigation = ({
   html?: string;
   children?: React.ReactNode;
 }) => {
-  // We need to create a popover and a form to submit this
-  // For testing please use your email here
-  async function handleClick(html?: string) {
-    if (!html) return;
-    const response = await fetch("https://react.email/api/send/test", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        to: "sosa@webscope.io",
-        subject: "Testing from MailingUI",
-        html,
-      }),
-    });
-
-    if (response.status === 429) {
-      const { error } = await response.json();
-      alert(error);
-    }
-  }
-
   return (
     <nav className="flex items-center justify-between gap-2 p-3">
       <div className="flex items-center gap-1">
@@ -48,13 +28,7 @@ export const PreviewNavigation = ({
       </div>
       <div className="flex items-center gap-4">
         {children}
-        <CTA
-          color="white"
-          className={cn("px-4 py-3", !html && "pointer-events-none opacity-75")}
-          onClick={() => handleClick(html)}
-        >
-          Send Test
-        </CTA>
+        <PreviewSend html={html} />
       </div>
     </nav>
   );

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -47,7 +47,7 @@ export const PreviewSend = ({ html }: { html?: string }) => {
         >
           <form onSubmit={onSubmitHandler}>
             <div className="grid w-full gap-4">
-              <div className="grid w-full items-center gap-1.5">
+              <div className="grid w-full items-center gap-2">
                 <label
                   htmlFor="email_address"
                   className="text-sm font-semibold leading-none"
@@ -67,7 +67,7 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                 />
               </div>
 
-              <div className="grid w-full max-w-sm items-center gap-1.5">
+              <div className="grid w-full max-w-sm items-center gap-2">
                 <label
                   htmlFor="subject"
                   className="text-sm font-semibold leading-none"
@@ -85,9 +85,20 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                   aria-label="subject"
                 />
               </div>
-              <CTA color="white" type="submit">
-                Send
-              </CTA>
+              <div className="grid grid-cols-3 items-center">
+                <p className="col-span-2 text-sm">
+                  Powered by{" "}
+                  <a
+                    className="font-semibold hover:opacity-70"
+                    href="https://react.email/"
+                  >
+                    react.email
+                  </a>
+                </p>
+                <CTA color="white" type="submit" className="py-2">
+                  Send
+                </CTA>
+              </div>
             </div>
           </form>
         </Popover.Content>

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -4,14 +4,20 @@ import React from "react";
 import * as Popover from "@radix-ui/react-popover";
 import { CTA } from "@components/CTA";
 import { cn } from "@utils/cn";
+import { CrossIcon, CheckIcon } from "@components/Icons";
 
 export const PreviewSend = ({ html }: { html?: string }) => {
   const [email, setEmail] = React.useState("");
   const [subject, setSubject] = React.useState("Testing from MailingUI");
+  const [status, setStatus] = React.useState<
+    "idle" | "sending" | "error" | "success"
+  >("idle");
 
   async function onSubmitHandler(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    setStatus("sending");
     if (!html) return;
+
     const response = await fetch("https://react.email/api/send/test", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -22,9 +28,12 @@ export const PreviewSend = ({ html }: { html?: string }) => {
       }),
     });
 
-    if (response.status === 429) {
-      const { error } = await response.json();
-      alert(error);
+    if (!response.ok) {
+      // Log error?
+      // const { error } = await response.json();
+      setStatus("error");
+    } else {
+      setStatus("success");
     }
   }
 
@@ -56,13 +65,17 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                 </label>
                 <input
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e) => {
+                    setStatus("idle");
+                    setEmail(e.target.value);
+                  }}
                   className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
                   type="email"
                   name="email_address"
                   id="email_address"
                   placeholder="Your email"
                   aria-label="email"
+                  disabled={status === "sending"}
                   required
                 />
               </div>
@@ -76,15 +89,20 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                 </label>
                 <input
                   value={subject}
-                  onChange={(e) => setSubject(e.target.value)}
+                  onChange={(e) => {
+                    setStatus("idle");
+                    setSubject(e.target.value);
+                  }}
                   className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
                   type="text"
                   name="subject"
                   id="subject"
                   placeholder="Subject"
                   aria-label="subject"
+                  disabled={status === "sending"}
                 />
               </div>
+
               <div className="grid grid-cols-3 items-center">
                 <p className="col-span-2 text-sm">
                   Powered by{" "}
@@ -95,8 +113,26 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                     react.email
                   </a>
                 </p>
-                <CTA color="white" type="submit" className="py-2">
-                  Send
+                <CTA
+                  color="white"
+                  type="submit"
+                  className="flex items-center justify-center gap-1 px-3 py-2 disabled:opacity-75"
+                  disabled={status !== "idle"}
+                >
+                  {status === "idle" && "Send"}
+                  {status === "error" && (
+                    <>
+                      <CrossIcon /> Error
+                    </>
+                  )}
+                  {status === "success" && (
+                    <>
+                      <CheckIcon /> Sent
+                    </>
+                  )}
+                  {status === "sending" && (
+                    <span className="animate-bounce">...</span>
+                  )}
                 </CTA>
               </div>
             </div>

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { CTA } from "@components/CTA";
+import { cn } from "@utils/cn";
+
+export const PreviewSend = ({ html }: { html?: string }) => {
+  // We need to create a popover and a form to submit this
+  // For testing please use your email here
+  async function handleClick(html?: string) {
+    if (!html) return;
+    const response = await fetch("https://react.email/api/send/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to: "sosa@webscope.io",
+        subject: "Testing from MailingUI",
+        html,
+      }),
+    });
+
+    if (response.status === 429) {
+      const { error } = await response.json();
+      alert(error);
+    }
+  }
+
+  return (
+    <CTA
+      color="white"
+      className={cn("px-4 py-3", !html && "pointer-events-none opacity-75")}
+      onClick={() => handleClick(html)}
+    >
+      Send Test
+    </CTA>
+  );
+};

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -122,12 +122,12 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                   {status === "idle" && "Send"}
                   {status === "error" && (
                     <>
-                      <CrossIcon /> Error
+                      <CrossIcon width="1.2rem" height="1.2rem" /> Error
                     </>
                   )}
                   {status === "success" && (
                     <>
-                      <CheckIcon /> Sent
+                      <CheckIcon width="1.2rem" height="1.2rem" /> Sent
                     </>
                   )}
                   {status === "sending" && (

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -1,19 +1,23 @@
 "use client";
 
+import React from "react";
+import * as Popover from "@radix-ui/react-popover";
 import { CTA } from "@components/CTA";
 import { cn } from "@utils/cn";
 
 export const PreviewSend = ({ html }: { html?: string }) => {
-  // We need to create a popover and a form to submit this
-  // For testing please use your email here
-  async function handleClick(html?: string) {
+  const [email, setEmail] = React.useState("");
+  const [subject, setSubject] = React.useState("Testing from MailingUI");
+
+  async function onSubmitHandler(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
     if (!html) return;
     const response = await fetch("https://react.email/api/send/test", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        to: "sosa@webscope.io",
-        subject: "Testing from MailingUI",
+        to: email,
+        subject,
         html,
       }),
     });
@@ -25,12 +29,69 @@ export const PreviewSend = ({ html }: { html?: string }) => {
   }
 
   return (
-    <CTA
-      color="white"
-      className={cn("px-4 py-3", !html && "pointer-events-none opacity-75")}
-      onClick={() => handleClick(html)}
-    >
-      Send Test
-    </CTA>
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <CTA
+          color="white"
+          className={cn("px-4 py-3", !html && "pointer-events-none opacity-75")}
+        >
+          Send Test
+        </CTA>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          alignOffset={8}
+          sideOffset={16}
+          className="w-80 rounded-xl bg-black p-4 text-white"
+        >
+          <form onSubmit={onSubmitHandler}>
+            <div className="grid w-full gap-4">
+              <div className="grid w-full items-center gap-1.5">
+                <label
+                  htmlFor="email_address"
+                  className="text-sm font-semibold leading-none"
+                >
+                  Email
+                </label>
+                <input
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
+                  type="email"
+                  name="email_address"
+                  id="email_address"
+                  placeholder="Your email"
+                  aria-label="email"
+                  required
+                />
+              </div>
+
+              <div className="grid w-full max-w-sm items-center gap-1.5">
+                <label
+                  htmlFor="subject"
+                  className="text-sm font-semibold leading-none"
+                >
+                  Subject
+                </label>
+                <input
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
+                  type="text"
+                  name="subject"
+                  id="subject"
+                  placeholder="Subject"
+                  aria-label="subject"
+                />
+              </div>
+              <CTA color="white" type="submit">
+                Send
+              </CTA>
+            </div>
+          </form>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 };

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -7,6 +7,7 @@ import { cn } from "@utils/cn";
 import { CrossIcon, CheckIcon } from "@components/Icons";
 
 export const PreviewSend = ({ html }: { html?: string }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
   const [email, setEmail] = React.useState("");
   const [subject, setSubject] = React.useState("Testing from MailingUI");
   const [status, setStatus] = React.useState<
@@ -38,13 +39,16 @@ export const PreviewSend = ({ html }: { html?: string }) => {
   }
 
   return (
-    <Popover.Root>
+    <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
       <Popover.Trigger asChild>
         <CTA
           color="white"
-          className={cn("px-4 py-3", !html && "pointer-events-none opacity-75")}
+          className={cn(
+            "px-4 py-3 min-w-[8rem]",
+            !html && "pointer-events-none opacity-75"
+          )}
         >
-          Send Test
+          {isOpen ? "Close Form" : "Send Test"}
         </CTA>
       </Popover.Trigger>
       <Popover.Portal>
@@ -59,7 +63,7 @@ export const PreviewSend = ({ html }: { html?: string }) => {
               <div className="grid w-full items-center gap-2">
                 <label
                   htmlFor="email_address"
-                  className="text-sm font-semibold leading-none"
+                  className="text-sm font-semibold leading-none opacity-75"
                 >
                   Email
                 </label>
@@ -71,10 +75,8 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                   }}
                   className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
                   type="email"
-                  name="email_address"
                   id="email_address"
                   placeholder="Your email"
-                  aria-label="email"
                   disabled={status === "sending"}
                   required
                 />
@@ -83,7 +85,7 @@ export const PreviewSend = ({ html }: { html?: string }) => {
               <div className="grid w-full max-w-sm items-center gap-2">
                 <label
                   htmlFor="subject"
-                  className="text-sm font-semibold leading-none"
+                  className="text-sm font-semibold leading-none opacity-75"
                 >
                   Subject
                 </label>
@@ -95,10 +97,8 @@ export const PreviewSend = ({ html }: { html?: string }) => {
                   }}
                   className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
                   type="text"
-                  name="subject"
                   id="subject"
                   placeholder="Subject"
-                  aria-label="subject"
                   disabled={status === "sending"}
                 />
               </div>

--- a/src/app/preview/components/PreviewSend.tsx
+++ b/src/app/preview/components/PreviewSend.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import * as Popover from "@radix-ui/react-popover";
 import { CTA } from "@components/CTA";
 import { cn } from "@utils/cn";
 import { CrossIcon, CheckIcon } from "@components/Icons";
+import { Popover, PopoverContent, PopoverTrigger } from "@components/Popover";
 
 export const PreviewSend = ({ html }: { html?: string }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -39,8 +39,8 @@ export const PreviewSend = ({ html }: { html?: string }) => {
   }
 
   return (
-    <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
-      <Popover.Trigger asChild>
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
         <CTA
           color="white"
           className={cn(
@@ -50,95 +50,88 @@ export const PreviewSend = ({ html }: { html?: string }) => {
         >
           {isOpen ? "Close Form" : "Send Test"}
         </CTA>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          align="end"
-          alignOffset={8}
-          sideOffset={16}
-          className="w-80 rounded-xl bg-black p-4 text-white"
-        >
-          <form onSubmit={onSubmitHandler}>
-            <div className="grid w-full gap-4">
-              <div className="grid w-full items-center gap-2">
-                <label
-                  htmlFor="email_address"
-                  className="text-sm font-semibold leading-none opacity-75"
-                >
-                  Email
-                </label>
-                <input
-                  value={email}
-                  onChange={(e) => {
-                    setStatus("idle");
-                    setEmail(e.target.value);
-                  }}
-                  className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
-                  type="email"
-                  id="email_address"
-                  placeholder="Your email"
-                  disabled={status === "sending"}
-                  required
-                />
-              </div>
-
-              <div className="grid w-full max-w-sm items-center gap-2">
-                <label
-                  htmlFor="subject"
-                  className="text-sm font-semibold leading-none opacity-75"
-                >
-                  Subject
-                </label>
-                <input
-                  value={subject}
-                  onChange={(e) => {
-                    setStatus("idle");
-                    setSubject(e.target.value);
-                  }}
-                  className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
-                  type="text"
-                  id="subject"
-                  placeholder="Subject"
-                  disabled={status === "sending"}
-                />
-              </div>
-
-              <div className="grid grid-cols-3 items-center">
-                <p className="col-span-2 text-sm">
-                  Powered by{" "}
-                  <a
-                    className="font-semibold hover:opacity-70"
-                    href="https://react.email/"
-                  >
-                    react.email
-                  </a>
-                </p>
-                <CTA
-                  color="white"
-                  type="submit"
-                  className="flex items-center justify-center gap-1 px-3 py-2 disabled:opacity-75"
-                  disabled={status !== "idle"}
-                >
-                  {status === "idle" && "Send"}
-                  {status === "error" && (
-                    <>
-                      <CrossIcon width="1.2rem" height="1.2rem" /> Error
-                    </>
-                  )}
-                  {status === "success" && (
-                    <>
-                      <CheckIcon width="1.2rem" height="1.2rem" /> Sent
-                    </>
-                  )}
-                  {status === "sending" && (
-                    <span className="animate-bounce">...</span>
-                  )}
-                </CTA>
-              </div>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={16} color="black">
+        <form onSubmit={onSubmitHandler}>
+          <div className="grid w-full gap-4">
+            <div className="grid w-full items-center gap-2">
+              <label
+                htmlFor="email_address"
+                className="text-sm font-semibold leading-none opacity-75"
+              >
+                Email
+              </label>
+              <input
+                value={email}
+                onChange={(e) => {
+                  setStatus("idle");
+                  setEmail(e.target.value);
+                }}
+                className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
+                type="email"
+                id="email_address"
+                placeholder="Your email"
+                disabled={status === "sending"}
+                required
+              />
             </div>
-          </form>
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+
+            <div className="grid w-full max-w-sm items-center gap-2">
+              <label
+                htmlFor="subject"
+                className="text-sm font-semibold leading-none opacity-75"
+              >
+                Subject
+              </label>
+              <input
+                value={subject}
+                onChange={(e) => {
+                  setStatus("idle");
+                  setSubject(e.target.value);
+                }}
+                className="w-full rounded-xl border border-solid border-dark-700 bg-dark-800 px-4 py-3 text-sm font-medium text-white placeholder:text-dark-300"
+                type="text"
+                id="subject"
+                placeholder="Subject"
+                disabled={status === "sending"}
+              />
+            </div>
+
+            <div className="grid grid-cols-3 items-center">
+              <p className="col-span-2 text-sm">
+                Powered by{" "}
+                <a
+                  className="font-semibold hover:opacity-70"
+                  href="https://react.email/"
+                >
+                  react.email
+                </a>
+              </p>
+              <CTA
+                color="white"
+                type="submit"
+                className="flex items-center justify-center gap-1 px-3 py-2 disabled:opacity-75"
+                disabled={status !== "idle"}
+              >
+                {status === "idle" && "Send"}
+                {status === "error" && (
+                  <>
+                    <CrossIcon width="1.2rem" height="1.2rem" /> Error
+                  </>
+                )}
+                {status === "success" && (
+                  <>
+                    <CheckIcon width="1.2rem" height="1.2rem" /> Sent
+                  </>
+                )}
+                {status === "sending" && (
+                  <span className="animate-bounce">...</span>
+                )}
+              </CTA>
+            </div>
+          </div>
+        </form>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/src/components/CTA/CTA.tsx
+++ b/src/components/CTA/CTA.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 import { cn } from "@utils/cn";
 
@@ -17,7 +18,10 @@ type CTAProps = (AsLinkProps | AsButtonProps) & {
   color: keyof typeof COLORS;
 };
 
-export const CTA: React.FC<CTAProps> = ({ color, className, ...delegated }) => {
+export const CTA = React.forwardRef<
+  HTMLAnchorElement & HTMLButtonElement,
+  CTAProps
+>(({ color, className, ...delegated }, ref) => {
   const mergedClassName = cn(
     "inline-flex items-center justify-center rounded-xl py-4 px-6 font-medium hover:opacity-70",
     COLORS[color],
@@ -25,8 +29,10 @@ export const CTA: React.FC<CTAProps> = ({ color, className, ...delegated }) => {
   );
 
   if (delegated.href !== undefined) {
-    return <Link {...delegated} className={mergedClassName} />;
+    return <Link {...delegated} className={mergedClassName} ref={ref} />;
   }
 
-  return <button {...delegated} className={mergedClassName} />;
-};
+  return <button {...delegated} className={mergedClassName} ref={ref} />;
+});
+
+CTA.displayName = "CTA";

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@utils/cn";
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverClose, PopoverAnchor };
+
+const COLORS = {
+  white: "bg-white text-black",
+  black: "bg-black text-white",
+} as const;
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverClose = PopoverPrimitive.Close;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+type PopoverContentProps = React.ComponentPropsWithoutRef<
+  typeof PopoverPrimitive.Content
+> & {
+  color: keyof typeof COLORS;
+};
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  PopoverContentProps
+>(({ className, align = "center", color, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      className={cn(
+        "z-50 w-80 rounded-xl p-4 shadow-md outline-none",
+        COLORS[color],
+        className
+      )}
+      {...props}
+    ></PopoverPrimitive.Content>
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,0 +1,7 @@
+export {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  PopoverClose,
+  PopoverAnchor,
+} from "./Popover";


### PR DESCRIPTION
Implements basic dropover form for Preview test send #111 

- follows react.email feat with few differences
- basic implementations, radix used for popover, but custom input/labels used in form (if there are more occurences of these expected, reusable common components could be added (radix/react-hook-form), but though its not worth it for this simple form) 
- simple email state indicators added inside send button