### PR TITLE
Increase static page generation timeout from default 60s to 300s

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   experimental: {
     appDir: true,
   },
+  staticPageGenerationTimeout: 300,
 
   images: {
     remotePatterns: [


### PR DESCRIPTION
I forked the project to investigate the issue further. I created a new Vercel project with that forked repo and got the same error twice in a row.

I increased the `staticPageGenerationTimeout` from 1 minute to 5 minutes and I could now get 5 consecutive successful builds, so I think the only issue was that generation of the static pages was taking too long.

I also tried to run some measurements on templates I created to see if the issue could be the `shiki` library (as we had performance issues with that in the past), and indeed highlighting the code took around 10 seconds on average for each template.

![image](https://github.com/webscopeio/mailingui-web/assets/48859243/9c852502-3adb-4a73-98f4-6fd391056679)

But that's still just 11 seconds and the timeout was 60 seconds, so the rest of the time must be buried somewhere else.

Below you can see that after setting the `staticPageGenerationTimeout` to a higher value than `60` the errors stopped happening.

![image](https://github.com/webscopeio/mailingui-web/assets/48859243/892f2415-8998-4f43-805f-8628d7e8f86e)
