### PR TITLE
Code components

### DIFF
--- a/src/docs/components/Code/Code.tsx
+++ b/src/docs/components/Code/Code.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import * as React from "react";
+
+interface CodeProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<"div">,
+    "dangerouslySetInnerHTML"
+  > {
+  htmlCode: string;
+}
+
+export const Code = React.forwardRef<React.ElementRef<"div">, CodeProps>(
+  ({ htmlCode, ...props }, ref) => (
+    <div ref={ref} dangerouslySetInnerHTML={{ __html: htmlCode }} {...props} />
+  )
+);
+Code.displayName = "Code";

--- a/src/docs/components/Code/TabbedCode.tsx
+++ b/src/docs/components/Code/TabbedCode.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import { Code } from "./Code";
+import { Tabs } from "@components/Tabs";
+import { TabsContent, TabsList, TabsTrigger } from "@components/Tabs/Tabs";
+import { CopyButton } from "@components/CopyButton";
+import { cn } from "@utils/cn";
+
+export interface TabbedCodeItem {
+  id: string;
+  label?: string;
+  htmlCode: string;
+  isPlainText?: boolean;
+}
+
+interface TabbedCodeProps {
+  className?: string;
+  collapsedClassName?: string;
+  expandedClassName?: string;
+  tabs: TabbedCodeItem[];
+}
+
+const CodeExpandableFooter = ({
+  expanded,
+  setExpanded,
+}: {
+  expanded: boolean;
+  setExpanded: (value: boolean) => void;
+}) => (
+  <footer
+    className={cn(
+      "absolute pointer-events-none rounded-md h-full w-full inset-0 bg-gradient-to-t from-slate-900 flex justify-center items-end pb-8",
+      expanded ? "pb-2 bg-none" : "pb-8"
+    )}
+  >
+    <button
+      onClick={() => setExpanded(!expanded)}
+      className={cn([
+        expanded
+          ? "text-xs px-2 py-1"
+          : "text-sm px-3 py-1.5 bg-neutral-200 text-neutral-800",
+        "pointer-events-auto rounded-md font-medium transition-all duration-300",
+        /** Hover styles */
+        expanded
+          ? "hover:bg-slate-800 hover:text-white"
+          : "hover:bg-neutral-400",
+        /** Focus styles */
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-400 focus-visible:ring-offset-2 ring-offset-dark-800",
+        /** Disabled styles */
+        "disabled:pointer-events-none disabled:opacity-50",
+      ])}
+    >
+      {!expanded ? "Expand" : "Collapse"}
+    </button>
+  </footer>
+);
+
+export const TabbedCode = ({
+  collapsedClassName,
+  expandedClassName,
+  className,
+  tabs,
+}: TabbedCodeProps) => {
+  const isExpandable = collapsedClassName || expandedClassName;
+
+  const [code, setCode] = React.useState("");
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  return (
+    <>
+      <Tabs
+        className={cn(
+          "bg-[#011627]",
+          className,
+          isExpanded ? expandedClassName : collapsedClassName
+        )}
+        defaultValue={tabs[0].id}
+      >
+        <div className="flex items-center justify-between px-5 pt-3">
+          <TabsList className="grid w-full bg-[#011627] sm:inline-flex">
+            {tabs.map(({ id, label }) => (
+              <TabsTrigger
+                key={id}
+                value={id}
+                className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
+              >
+                {label ?? id}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <div className="hidden md:inline-flex">
+            <CopyButton code={code} />
+          </div>
+        </div>
+        {tabs.map(({ id, htmlCode, isPlainText }) => (
+          <TabsContent key={id} value={id}>
+            <Code
+              className={cn(isPlainText && "whitespace-pre-line px-8 pb-8")}
+              ref={(node) => {
+                node?.textContent && setCode(node.textContent);
+              }}
+              htmlCode={htmlCode}
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
+      {isExpandable && (
+        <CodeExpandableFooter
+          expanded={isExpanded}
+          setExpanded={setIsExpanded}
+        />
+      )}
+    </>
+  );
+};
+TabbedCode.displayName = "TabbedCode";

--- a/src/docs/components/Code/index.ts
+++ b/src/docs/components/Code/index.ts
@@ -1,0 +1,2 @@
+export { TabbedCode, type TabbedCodeItem } from "./TabbedCode";
+export { Code } from "./Code";

--- a/src/docs/components/ComponentExample/ComponentExample.tsx
+++ b/src/docs/components/ComponentExample/ComponentExample.tsx
@@ -3,9 +3,9 @@ import * as React from "react";
 import { Resizable } from "re-resizable";
 import { Tabs } from "@components/Tabs";
 import { CodeIcon, EyeIcon } from "@components/Icons";
-import { CopyButton } from "@components/CopyButton";
 import { cn } from "@utils/cn";
 import { TabsContent, TabsList, TabsTrigger } from "@components/Tabs/Tabs";
+import { TabbedCode, TabbedCodeItem } from "@components/Code";
 
 export type ComponentExampleProps = {
   type: string;
@@ -24,8 +24,21 @@ export const ComponentExample = ({
   markup,
   plainText,
 }: ComponentExampleProps) => {
-  const [code, setCode] = React.useState("");
-  const [expanded, setExpanded] = React.useState(false);
+  const tabData: TabbedCodeItem[] = [
+    {
+      id: `${id}.tsx`,
+      htmlCode: source,
+    },
+    {
+      id: `${id}.html`,
+      htmlCode: markup,
+    },
+    {
+      id: `${id}.txt`,
+      htmlCode: plainText,
+      isPlainText: true,
+    },
+  ];
 
   return (
     <div className={cn("space-y-3")}>
@@ -85,96 +98,11 @@ export const ComponentExample = ({
           className="relative overflow-hidden rounded-md"
           value="code"
         >
-          <div
-            className={cn(
-              "bg-[#011627] min-h-[350px]",
-              !expanded && "max-h-[350px]"
-            )}
-          >
-            <Tabs defaultValue="source">
-              <div className="flex items-center justify-between px-5 pt-3">
-                <TabsList className="grid w-full bg-[#011627] sm:inline-flex">
-                  <TabsTrigger
-                    value="source"
-                    className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                  >
-                    {id}.tsx
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="markup"
-                    className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                  >
-                    {id}.html
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="text"
-                    className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                  >
-                    {id}.txt
-                  </TabsTrigger>
-                </TabsList>
-                <div className="hidden md:inline-flex">
-                  <CopyButton code={code} />
-                </div>
-              </div>
-              <TabsContent value="source">
-                <div
-                  tabIndex={-1}
-                  ref={(node) => {
-                    node?.textContent && setCode(node.textContent);
-                  }}
-                  dangerouslySetInnerHTML={{ __html: source }}
-                />
-              </TabsContent>
-              <TabsContent value="markup">
-                <div
-                  tabIndex={-1}
-                  ref={(node) => {
-                    node?.textContent && setCode(node.textContent);
-                  }}
-                  dangerouslySetInnerHTML={{ __html: markup }}
-                />
-              </TabsContent>
-              <TabsContent className="h-full overscroll-none" value="text">
-                <div
-                  className="whitespace-pre-line px-8 pb-8"
-                  tabIndex={-1}
-                  ref={(node) => {
-                    node?.textContent && setCode(node.textContent);
-                  }}
-                  dangerouslySetInnerHTML={{
-                    __html: plainText,
-                  }}
-                />
-              </TabsContent>
-            </Tabs>
-          </div>
-          <footer
-            className={cn(
-              "absolute pointer-events-none rounded-md h-full w-full inset-0 bg-gradient-to-t from-slate-900 flex justify-center items-end pb-8",
-              expanded ? "pb-2 bg-none" : "pb-8"
-            )}
-          >
-            <button
-              onClick={() => setExpanded(!expanded)}
-              className={cn([
-                expanded
-                  ? "text-xs px-2 py-1"
-                  : "text-sm px-3 py-1.5 bg-neutral-200 text-neutral-800",
-                "pointer-events-auto rounded-md font-medium transition-all duration-300",
-                /** Hover styles */
-                expanded
-                  ? "hover:bg-slate-800 hover:text-white"
-                  : "hover:bg-neutral-400",
-                /** Focus styles */
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-400 focus-visible:ring-offset-2 ring-offset-dark-800",
-                /** Disabled styles */
-                "disabled:pointer-events-none disabled:opacity-50",
-              ])}
-            >
-              {!expanded ? "Expand" : "Collapse"}
-            </button>
-          </footer>
+          <TabbedCode
+            tabs={tabData}
+            collapsedClassName="max-h-[350px]"
+            className="min-h-[350px]"
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/docs/components/EmailPreview/PreviewPane.tsx
+++ b/src/docs/components/EmailPreview/PreviewPane.tsx
@@ -9,8 +9,7 @@ import {
   TabsTrigger,
 } from "@components/Tabs/Tabs";
 import { CodeIcon, EyeIcon } from "@components/Icons";
-import { cn } from "@utils/cn";
-import { CopyButton } from "@components/CopyButton";
+import { TabbedCode, TabbedCodeItem } from "@components/Code";
 
 export const PreviewPane = ({
   id,
@@ -25,10 +24,25 @@ export const PreviewPane = ({
     plainText: string;
   };
 }) => {
-  const [code, setCode] = React.useState("");
+  const tabData: TabbedCodeItem[] = [
+    {
+      id: `${data.id}.tsx`,
+      htmlCode: data.source,
+    },
+    {
+      id: `${data.id}.html`,
+      htmlCode: data.markup,
+    },
+    {
+      id: `${data.id}.txt`,
+      htmlCode: data.plainText,
+      isPlainText: true,
+    },
+  ];
+
   return (
     <Tabs
-      className="h-full w-full overflow-hidden"
+      className="flex h-full w-full flex-col overflow-hidden"
       defaultValue="preview"
       orientation="horizontal"
     >
@@ -45,7 +59,7 @@ export const PreviewPane = ({
         </TabsList>
       </PreviewNavigation>
       <TabsContent
-        className="relative h-full w-full overflow-y-scroll data-[orientation=horizontal]:mt-0"
+        className="relative w-full overflow-y-scroll data-[orientation=horizontal]:mt-0"
         value="preview"
       >
         <iframe
@@ -59,68 +73,10 @@ export const PreviewPane = ({
         />
       </TabsContent>
       <TabsContent
-        className="relative h-full w-full overflow-y-scroll data-[orientation=horizontal]:mt-0"
+        className="relative w-full overflow-y-scroll data-[orientation=horizontal]:mt-0"
         value="code"
       >
-        <div className={cn("bg-[#011627] min-h-full")}>
-          <Tabs defaultValue="source">
-            <div className="flex items-center justify-between px-5 pt-3">
-              <TabsList className="grid w-full bg-[#011627] sm:inline-flex">
-                <TabsTrigger
-                  value="source"
-                  className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                >
-                  {id}.tsx
-                </TabsTrigger>
-                <TabsTrigger
-                  value="markup"
-                  className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                >
-                  {id}.html
-                </TabsTrigger>
-                <TabsTrigger
-                  value="text"
-                  className="px-2.5 py-1.5 text-xs hover:bg-slate-700/50 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-200"
-                >
-                  {id}.txt
-                </TabsTrigger>
-              </TabsList>
-              <div className="hidden md:inline-flex">
-                <CopyButton code={code} />
-              </div>
-            </div>
-            <TabsContent value="source">
-              <div
-                tabIndex={-1}
-                ref={(node) => {
-                  node?.textContent && setCode(node.textContent);
-                }}
-                dangerouslySetInnerHTML={{ __html: data.source }}
-              />
-            </TabsContent>
-            <TabsContent value="markup">
-              <div
-                tabIndex={-1}
-                ref={(node) => {
-                  node?.textContent && setCode(node.textContent);
-                }}
-                dangerouslySetInnerHTML={{ __html: data.markup }}
-              />
-            </TabsContent>
-            <TabsContent value="text">
-              <div
-                className="whitespace-pre-line px-8 pb-8"
-                tabIndex={-1}
-                ref={(node) => {
-                  node?.textContent && setCode(node.textContent);
-                }}
-                dangerouslySetInnerHTML={{
-                  __html: data.plainText,
-                }}
-              />
-            </TabsContent>
-          </Tabs>
-        </div>
+        <TabbedCode className="min-h-full" tabs={tabData} />
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
resolves #118 

- refactor code tabs into reusable components
- should work for both variants currently utilizing TabbedCode 
- note: isPlainText passed in data (necessary for styling) but guess tabs could try to be smart and detect it