### PR TITLE
create `Head` component + use it where needed

### DIFF
--- a/src/docs/examples/badges/DotBadges.tsx
+++ b/src/docs/examples/badges/DotBadges.tsx
@@ -2,25 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const DotBadges = () => (
   <Html>
-    <Head>
-      <style
-        id="stitches"
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Medium Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/docs/examples/badges/LargeBadges.tsx
+++ b/src/docs/examples/badges/LargeBadges.tsx
@@ -2,24 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const LargeBadges = () => (
   <Html>
-    <Head>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Large Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/docs/examples/badges/MediumBadges.tsx
+++ b/src/docs/examples/badges/MediumBadges.tsx
@@ -2,24 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const MediumBadges = () => (
   <Html>
-    <Head>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Medium Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/docs/examples/badges/NoBorderBadges.tsx
+++ b/src/docs/examples/badges/NoBorderBadges.tsx
@@ -2,24 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const MediumBadges = () => (
   <Html>
-    <Head>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Medium Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/docs/examples/badges/PillBadges.tsx
+++ b/src/docs/examples/badges/PillBadges.tsx
@@ -2,24 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const PillBadges = () => (
   <Html>
-    <Head>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Pill Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/docs/examples/badges/SmallBadges.tsx
+++ b/src/docs/examples/badges/SmallBadges.tsx
@@ -2,24 +2,15 @@ import * as React from "react";
 import {
   Body,
   Container,
-  Head,
   Html,
   Preview,
   Section,
 } from "@react-email/components";
-import { Badge } from "@mailingui/components";
-import { getCssText } from "@mailingui/utils";
+import { Badge, Head } from "@mailingui/components";
 
 const SmallBadges = () => (
   <Html>
-    <Head>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{
-          __html: getCssText(),
-        }}
-      />
-    </Head>
+    <Head />
     <Preview>Small Badges</Preview>
     <Body style={main}>
       <Container style={container}>

--- a/src/emails/booking-confirmation.tsx
+++ b/src/emails/booking-confirmation.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type MinimalBookingConfirmationProps = {
@@ -33,9 +33,7 @@ const baseUrl = `${
   process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : ""
 }/static/minimal-theme`;
 
-export const BookingConfirmation: FC<
-  MinimalBookingConfirmationProps
-> = ({
+export const BookingConfirmation: FC<MinimalBookingConfirmationProps> = ({
   name = "Jacob",
   checkInDate = "August 22, 2023",
   checkOutDate = "September 5, 2023",

--- a/src/emails/competition.tsx
+++ b/src/emails/competition.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type CompetitionProps = {

--- a/src/emails/dinner-reservation.tsx
+++ b/src/emails/dinner-reservation.tsx
@@ -2,14 +2,18 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
   Row,
 } from "@react-email/components";
 import React, { FC } from "react";
-import { Text, SocialIcon, type SocialIconType } from "@mailingui/components";
+import {
+  Text,
+  SocialIcon,
+  type SocialIconType,
+  Head,
+} from "@mailingui/components";
 
 type DinnerReservationProps = {
   name: string;

--- a/src/emails/discount-code.tsx
+++ b/src/emails/discount-code.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type MinimalResetPasswordProps = {

--- a/src/emails/event-invitation.tsx
+++ b/src/emails/event-invitation.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type MinimalResetPasswordProps = {

--- a/src/emails/join-our-team.tsx
+++ b/src/emails/join-our-team.tsx
@@ -2,14 +2,18 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
   Row,
 } from "@react-email/components";
 import React, { FC } from "react";
-import { Text, SocialIcon, type SocialIconType } from "@mailingui/components";
+import {
+  Text,
+  SocialIcon,
+  type SocialIconType,
+  Head,
+} from "@mailingui/components";
 
 type MinimalEventInvitationProps = {
   name: string;

--- a/src/emails/news.tsx
+++ b/src/emails/news.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -16,6 +15,7 @@ import {
   BulletList,
   BulletListItem,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type MinimalNewsProps = {

--- a/src/emails/reset-password.tsx
+++ b/src/emails/reset-password.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Button,
+  Head,
 } from "@mailingui/components";
 
 type MinimalResetPasswordProps = {

--- a/src/emails/review.tsx
+++ b/src/emails/review.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -14,6 +13,7 @@ import {
   SocialIcon,
   type SocialIconType,
   Emoji,
+  Head,
 } from "@mailingui/components";
 
 type MinimalReviewProps = {

--- a/src/emails/tips-for-trips.tsx
+++ b/src/emails/tips-for-trips.tsx
@@ -2,7 +2,6 @@ import {
   Body,
   Column,
   Container,
-  Head,
   Html,
   Preview,
   Img,
@@ -13,13 +12,14 @@ import {
   Text,
   SocialIcon,
   type SocialIconType,
+  Head,
 } from "@mailingui/components";
 
 type Tip = {
   title: string;
   description: string;
   imageUrl: string;
-}
+};
 
 type TipsForTripsProps = {
   name?: string;
@@ -29,26 +29,32 @@ type TipsForTripsProps = {
 const defaultTips: Tip[] = [
   {
     title: "1. Japan",
-    description: "Japan is a country of contrasts, where ancient traditions and modern technology coexist. From exploring the bustling city of Tokyo to soaking in hot springs and admiring the cherry blossoms, Japan has something for everyone.",
-    imageUrl: "/japan-trip-tip.png"
+    description:
+      "Japan is a country of contrasts, where ancient traditions and modern technology coexist. From exploring the bustling city of Tokyo to soaking in hot springs and admiring the cherry blossoms, Japan has something for everyone.",
+    imageUrl: "/japan-trip-tip.png",
   },
   {
     title: "2. Italy",
-    description: "Italy is a country of romance, art, and exquisite cuisine. Whether you're strolling through the streets of Rome, admiring the art in Florence, or savoring the delicious food in Naples, Italy is a destination that should be on everyone's bucket list.",
-    imageUrl: "/italy-trip-tip.png"
+    description:
+      "Italy is a country of romance, art, and exquisite cuisine. Whether you're strolling through the streets of Rome, admiring the art in Florence, or savoring the delicious food in Naples, Italy is a destination that should be on everyone's bucket list.",
+    imageUrl: "/italy-trip-tip.png",
   },
   {
     title: "3. Iceland",
-    description: "Iceland is a country of otherworldly landscapes, with hot springs, glaciers, and geysers. You can hike on glaciers, swim in hot springs, and chase the Northern Lights in this unique destination.",
-    imageUrl: "/iceland-trip-tip.png"
-  }
-]
+    description:
+      "Iceland is a country of otherworldly landscapes, with hot springs, glaciers, and geysers. You can hike on glaciers, swim in hot springs, and chase the Northern Lights in this unique destination.",
+    imageUrl: "/iceland-trip-tip.png",
+  },
+];
 
 const baseUrl = `${
   process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : ""
 }/static/minimal-theme`;
 
-export const TipsForTrips: FC<TipsForTripsProps> = ({ name = "Jacob", tips = defaultTips }) => {
+export const TipsForTrips: FC<TipsForTripsProps> = ({
+  name = "Jacob",
+  tips = defaultTips,
+}) => {
   return (
     <Html>
       <Head />
@@ -91,13 +97,14 @@ export const TipsForTrips: FC<TipsForTripsProps> = ({ name = "Jacob", tips = def
           </Row>
           {tips.map((tip, i) => (
             <Row key={i} style={{ marginBottom: "32px" }}>
-              <Text style={{ fontWeight: 700 }}>
-                {tip.title}
-              </Text>
+              <Text style={{ fontWeight: 700 }}>{tip.title}</Text>
               <Text>{tip.description}</Text>
-              <Img src={`${baseUrl}/${tip.imageUrl}`} style={{ borderRadius: "16px" }}/>
+              <Img
+                src={`${baseUrl}/${tip.imageUrl}`}
+                style={{ borderRadius: "16px" }}
+              />
             </Row>
-            ))}
+          ))}
           <Row style={{ marginBottom: "16px" }}>
             <Text>
               I hope these suggestions inspire you to plan your next trip. Each

--- a/src/mailingui/components/head/Head.tsx
+++ b/src/mailingui/components/head/Head.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentPropsWithoutRef, FC } from "react";
+import { Head as ReactEmailHead } from "@react-email/components";
+import { getCssText } from "@mailingui/utils";
+
+type HeadProps = ComponentPropsWithoutRef<"head">;
+
+const Head: FC<HeadProps> = ({ children, ...props }) => {
+  return (
+    <ReactEmailHead {...props}>
+      <style
+        id="stitches"
+        type="text/css"
+        dangerouslySetInnerHTML={{
+          __html: getCssText(),
+        }}
+      />
+      {children}
+    </ReactEmailHead>
+  );
+};
+
+export { Head };

--- a/src/mailingui/components/index.ts
+++ b/src/mailingui/components/index.ts
@@ -23,3 +23,4 @@ export {
   BulletListItem,
   type BulletListProps,
 } from "./list/BulletList";
+export { Head } from "./head/Head";


### PR DESCRIPTION
With the latest changes, every template/example would have to have the following code in the react.email's `Head` component:

```
<Head>
  <style
          id="stitches"
          type="text/css"
          dangerouslySetInnerHTML={{
            __html: getCssText(),
          }}
        />
</Head>
```

with this component, we automatically include this code in the `head` of the document, so we don't have to worry about adding it everywhere. This also stands for the users of our library, they don't have to worry about pasting this code into every email, they just use our component and are set.

The only drawback is that now, there are two similar components with the same name in our library and in `react-email` library and it is not very clear whether to import the one from our library or from `react-email`.

Possible solution: create wrappers for all the react-email components we are using (E.g. `<Html>`, `<Preview>`, `<Body>`...) so user just imports everything from our library. I know we talked about this, but with this PR, there is another reason for it.

wdyt guys? @iamhectorsosa @jvorcak 