### PR TITLE
fix /components styling

### DIFF
--- a/src/app/(with-navbar)/components/[type]/page.tsx
+++ b/src/app/(with-navbar)/components/[type]/page.tsx
@@ -56,7 +56,7 @@ export default async function ComponentPage({
   ) : null;
 
   return (
-    <div className="mx-auto w-full max-w-[900px] overflow-hidden p-4">
+    <div className="mx-auto w-full max-w-6xl overflow-hidden px-4">
       {Docs}
       <h2 className="pt-8 text-2xl font-semibold md:pt-16 md:text-4xl">
         {componentExamples.title}

--- a/src/app/(with-navbar)/layout.tsx
+++ b/src/app/(with-navbar)/layout.tsx
@@ -9,7 +9,7 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Navbar />
-      <div className="pb-16 md:pb-32">{children}</div>
+      <div className="pb-16 pt-8 md:pb-32 md:pt-16">{children}</div>
       <div className="mt-auto">
         <Footer />
       </div>

--- a/src/docs/components/InstallationDocs/DocArticle.tsx
+++ b/src/docs/components/InstallationDocs/DocArticle.tsx
@@ -5,7 +5,7 @@ export const DocArticle = (props: React.HTMLAttributes<HTMLDivElement>) => (
     {...props}
     className={cn(
       props.className,
-      "mx-auto my-8 max-w-none space-y-8 md:space-y-12"
+      "mx-auto max-w-none space-y-8 md:space-y-12"
     )}
   />
 );


### PR DESCRIPTION
Should unify styling bit and fix _"can you check if the layouts (w, m and p) are consistent for /components and /components/[type]. The title “MailingUI Components” seems very close to the navbar"_
Note that in figma design there is actually width difference (/components/[type]) more narrow, so width can be reverted. 
Note2 look on [badges](https://mailingui-git-fix-docs-sizing-webscopeio.vercel.app/components/badges) for component type example (others will be also correct when new mdx are merged)