### PR TITLE
Improve docs in `/components`

### DIFF
--- a/src/app/(with-navbar)/page.tsx
+++ b/src/app/(with-navbar)/page.tsx
@@ -14,7 +14,7 @@ const Home = () => (
       <FeaturePreview
         cta={{
           href: "/components",
-          title: "Explore Components",
+          title: "Explore All Components",
         }}
         title="Build an eye-catching email with pre-made components"
         previewType="components"

--- a/src/docs/components/Greeting/Greeting.tsx
+++ b/src/docs/components/Greeting/Greeting.tsx
@@ -42,7 +42,7 @@ export const Greeting = () => (
       </p>
       <div className="mt-6 space-y-3 md:mt-12 md:inline-flex md:gap-x-3 md:space-y-0">
         <CTA href="/components" color="white" className="w-full md:w-auto">
-          Explore components
+          Explore Components
         </CTA>
         <CTA
           href="https://github.com/webscopeio/mailingui-web/stargazers"

--- a/src/docs/examples/installation.mdx
+++ b/src/docs/examples/installation.mdx
@@ -1,8 +1,9 @@
 # MailingUI components
 
 MailingUI is a set of _opinionated_ React components designed to make the creation of emails easier.
-All of our
-components are intended to be used as copy-and-paste snippets.
+
+All of our components are intended to be used as copy-and-paste snippets, you **cannot install MailingUI
+as a dependency**.
 Right now, we are not planning on releasing an npm package for the components.
 
 ## Installation
@@ -11,7 +12,7 @@ To start using MailingUI in your project, you have to set up a few things.
 Follow the steps below to get started.<br />
 _Note:_ For the best experience, we recommend using MailingUI in a **Next.js** project with **TypeScript**.
 
-### (Optional) 1. Bootstrap a new Next.js project
+### (Optional) Bootstrap a new Next.js project
 
 If you already have a Next.js project, you can skip this step.
 Also, if you intend to use MailingUI in a different project, you can skip this step.
@@ -31,10 +32,10 @@ npm install @react-email/components @react-email/render
 
 ### Create a theme file
 
-To allow quick and easy customization of the components, our components consume a theme that you can change
+To allow quick and easy customization of the components, our components consume a theme that you can modify
 to fit your needs.
 
-To set up theming create a folder called `themes` somewhere in your project (we recommend `src/mailingui/themes`),
+To set up theming create a folder called `themes` in your project (we recommend `src/mailingui/themes`),
 create a file named `index.ts` inside the folder and paste the following code into it.
 
 ```typescript
@@ -80,7 +81,20 @@ Add the following lines to your `tsconfig.json` file:
 }
 ```
 
-_Note:_ If you are using a different folder structure, you will have to change the paths in the `tsconfig.json` file.
+> _Note:_ If you are using a different folder structure, you will have to change the paths in the `tsconfig.json` file.
+
+If you used the same naming as us, your file structure should include the following files:
+
+```tree
+├── /src
+│   ├── /mailingui
+│   │   ├── /themes
+│   │   │   ├── /index.ts
+│   │   ├── /components
+├── package.json
+├── tsconfig.json
+└── ...
+```
 
 Now you should be able to use MailingUI components in your project.
 Just click on one of the components below and follow the instructions on how to include it in your project.

--- a/src/docs/examples/installation.mdx
+++ b/src/docs/examples/installation.mdx
@@ -4,7 +4,7 @@ MailingUI is a set of _opinionated_ React components designed to make the creati
 
 All of our components are intended to be used as copy-and-paste snippets, you **cannot install MailingUI
 as a dependency**.
-Right now, we are not planning on releasing an npm package for the components.
+Right now, we have no plans on creating an npm package for the components.
 
 ## Installation
 


### PR DESCRIPTION
This PR is solving the #156 issue.

> I'd consider highlighting the fact that the components are intended to be used as copy-paste snippets (As this is not the usual approach and it might be confusing.)

we mention at the beginning that our components are intended to be used only as *copy and paste* components, but I made the mention a little more clear on the `/components` page to avoid confusion.

> I'd probably show an opinionated structure of the files that are necessary for the components to work (ideally somewhere close to the beginning of the docs). So that the users can have a better overview of what is necessary to set up as soon as possible.

added as a code block, but I think that should be sufficient. I was thinking about creating a component just for the filetree, but I think that should not be necessary.

> I'd consider simplifying the way we talk about the theme file. I'd probably only suggest the way we like the most sticking to a specific opinion and trying to prevent confusion. I don't really like the formulation of "place the file somewhere in the project". If we want to communicate the fact that it is not completely necessary to keep the structure, I'd rather mention it in a side note.

I agree with the confusion around _"place the file somewhere in the project"_, so I made that more opinionated,  but still left a note about the flexibility.

> Just a detail, but I don't quite like the fact that the theme alias reads "@mailingui/themes", while it exports just a single theme 😅

About the naming of the `@mailingui/themes`, if we decide to change that to `@mailingui/theme` we would also have to update all of the components (their code) and also the lib's internal code. I'm not sure if that's something we want, however it does not seem like a big task so I could include it in this PR, wdyt @iamhectorsosa ?