### PR TITLE
fix: Landing Page default export for examples

### DIFF
--- a/src/components/landing/Homepage.tsx
+++ b/src/components/landing/Homepage.tsx
@@ -11,12 +11,12 @@ import BlockquoteExample from "./examples/blockquote-example";
 import Links from "./examples/links";
 import Footer from "./examples/footer";
 import CustomerService from "./examples/customer-service";
+import GridCardExample from "./examples/grid-card-example";
+import GridDataExample from "./examples/grid-data-example";
+import CouponExample from "./examples/coupon-example";
 
 import { CTA } from "@components/ui/CTA";
 import { cn } from "@utils/cn";
-import { GridCardExample } from "./examples/grid-card-example";
-import { GridDataExample } from "./examples/grid-data-example";
-import CouponExample from "./examples/coupon-example";
 
 export const Homepage = () => {
   return (

--- a/src/components/landing/examples/grid-card-example.tsx
+++ b/src/components/landing/examples/grid-card-example.tsx
@@ -1,7 +1,7 @@
-import { Img, P, Grid, Cell } from "@mailingui/components";
 import { Container } from "@react-email/components";
+import { Img, P, Grid, Cell } from "@mailingui/components";
 
-export const GridCardExample = () => {
+export default function GridCardExample() {
   return (
     <Container style={container}>
       <Grid>
@@ -37,7 +37,7 @@ export const GridCardExample = () => {
       </Grid>
     </Container>
   );
-};
+}
 
 // Styles
 const container = {

--- a/src/components/landing/examples/grid-data-example.tsx
+++ b/src/components/landing/examples/grid-data-example.tsx
@@ -1,7 +1,7 @@
-import { Grid, Cell, P } from "@mailingui/components";
 import { Container } from "@react-email/components";
+import { Grid, Cell, P } from "@mailingui/components";
 
-export const GridDataExample = () => {
+export default function GridDataExample() {
   return (
     <Container style={container}>
       <Grid gap={6}>
@@ -20,7 +20,7 @@ export const GridDataExample = () => {
       </Grid>
     </Container>
   );
-};
+}
 
 // Styles
 const container = {


### PR DESCRIPTION
The landing page examles all should have default imports for the sake of consistency.